### PR TITLE
include the 'excon' gem with the default recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Use `auto_upgrade` recipe to upgrade your NetApp SANtricity Web Service Proxy
 
 NetApp E-Series connection
 -----------------
-In order to use the Resources provided by the cookbook you need in include the `default` recipe in your runlist. The connection is made over HTTPS through the SANtricity Web Services Proxy and the connection settings are managed by attributes.
+In order to use the Resources provided by the cookbook you need to include the `default` recipe in your run-list. The connection is made over HTTPS through the SANtricity Web Services Proxy and the connection settings are managed by attributes.
 
     ['netapp']['https'] boolean
     ['netapp']['user'] string

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ You need to rename the directory to netapp_e from netapp_e-cookbook in order to 
 
 #### NetApp SANtricity Web Service Proxy Upgrade
 
-Use 'auto_upgrade' recipe to upgrade your NetApp SANtricity Web Service Proxy
+Use `auto_upgrade` recipe to upgrade your NetApp SANtricity Web Service Proxy
 
 NetApp E-Series connection
 -----------------
-The connection is made over HTTPS through the SANtricity Web Services Proxy and the connection settings are managed by attributes.
+In order to use the Resources provided by the cookbook you need in include the `default` recipe in your runlist. The connection is made over HTTPS through the SANtricity Web Services Proxy and the connection settings are managed by attributes.
 
     ['netapp']['https'] boolean
     ['netapp']['user'] string
@@ -38,6 +38,10 @@ You need to have the necessary certificates in the environment path of machine i
 
 NetApp E-Series Recipes
 =======================
+
+default
+-------
+This recipe is required for using the cookbook's Resources, it installs the required `excon` gem for the Chef client.
 
 proxy
 -----
@@ -904,7 +908,7 @@ License and Authors
 - Authors:: Matt Ray (matt@getchef.com)
 
 ```text
-Copyright 2015 Chef Software, Inc.
+Copyright 2015-2016 Chef Software, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/libraries/netapp_e_series_api.rb
+++ b/libraries/netapp_e_series_api.rb
@@ -544,7 +544,11 @@ class NetApp
 
       # Make a call to the web proxy
       def request(method, path, body = nil)
-        require 'excon'
+        begin
+          require 'excon'
+        rescue LoadError
+          raise "The 'excon' gem is not available. Ensure the netapp_e::default recipe is at the beginning of your run-list before attempting to use netapp_e cookbook resources."
+        end
         if @basic_auth
           Excon.send(method, @url, path: path, headers: web_proxy_headers, body: body, connect_timeout: @connect_timeout, user: @user, password: @password)
         else

--- a/libraries/netapp_e_series_api.rb
+++ b/libraries/netapp_e_series_api.rb
@@ -1,5 +1,4 @@
 require 'json'
-require 'excon'
 
 class NetApp
   class ESeries
@@ -545,6 +544,7 @@ class NetApp
 
       # Make a call to the web proxy
       def request(method, path, body = nil)
+        require 'excon'
         if @basic_auth
           Excon.send(method, @url, path: path, headers: web_proxy_headers, body: body, connect_timeout: @connect_timeout, user: @user, password: @password)
         else

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'partnereng@chef.io'
 license          'Apache 2.0'
 description      'Manages NetApp E-Series storage systems'
 long_description 'Installs the NetApp SANtricity Web Services Proxy and manages E-Series storage systems'
-version          '1.0.0'
+version          '1.1.0'
 
 supports 'redhat'
 supports 'windows'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,0 +1,20 @@
+#
+# Cookbook Name:: netapp_e
+# Recipe:: default
+#
+# Copyright 2016, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+chef_gem 'excon'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,4 +17,6 @@
 # limitations under the License.
 #
 
-chef_gem 'excon'
+chef_gem 'excon' do
+  compile_time true
+end


### PR DESCRIPTION
The 'excon' gem is not a shipped dependency with the chef-client, so we're going to include it with the default recipe.